### PR TITLE
[mercadopago-sdk-js] Remove mercadopago and mercadocredito from excluded payment methods and types

### DIFF
--- a/types/mercadopago-sdk-js/mercadopago-sdk-js-tests.ts
+++ b/types/mercadopago-sdk-js/mercadopago-sdk-js-tests.ts
@@ -26,8 +26,9 @@ brickBuilder.isInitialized();
         },
         callbacks: {
             onSubmit: (formData, additionalData) => {
-                return new Promise(() => {
+                return new Promise((resolve) => {
                     console.log(formData, additionalData);
+                    resolve();
                 });
             },
         },

--- a/types/mercadopago-sdk-js/mercadopago-sdk-js-tests.ts
+++ b/types/mercadopago-sdk-js/mercadopago-sdk-js-tests.ts
@@ -164,7 +164,7 @@ brickBuilder.create("wallet", "containerWallet", {
     },
 });
 
-brickBuilder.create("brand", "containerBrand", {});
+brickBuilder.create("brand", "containerBrand");
 
 brickBuilder.create("brand", "containerBrand", {
     customization: {

--- a/types/mercadopago-sdk-js/mercadopago-sdk-js-tests.ts
+++ b/types/mercadopago-sdk-js/mercadopago-sdk-js-tests.ts
@@ -164,7 +164,17 @@ brickBuilder.create("wallet", "containerWallet", {
     },
 });
 
-brickBuilder.create("brand", "containerBrand");
+brickBuilder.create("brand", "containerBrand", {});
+
+brickBuilder.create("brand", "containerBrand", {
+    customization: {
+        paymentMethods: {
+            excludedPaymentMethods: ['amex'],
+            excludedPaymentTypes: ['ticket']
+        },
+    }
+});
+
 
 const fieldInstance = mpInstance.fields.create("cardNumber", {});
 fieldInstance.mount("containerId");

--- a/types/mercadopago-sdk-js/modules/bricks.d.ts
+++ b/types/mercadopago-sdk-js/modules/bricks.d.ts
@@ -479,13 +479,13 @@ declare namespace bricks {
     type BrandBrickBorderColor = "dark" | "light";
 
     interface BrandBrickPaymentMethodCustomization {
-        excludedPaymentMethods?: BrandBrickPaymentMethods[];
-        excludedPaymentTypes?: BrandBrickPaymentTypes[];
+        excludedPaymentMethods?: BrandBrickExcludedPaymentMethods[];
+        excludedPaymentTypes?: BrandBrickExcludedPaymentTypes[];
         maxInstallments?: number;
         interestFreeInstallments?: boolean;
     }
 
-    type BrandBrickPaymentMethods =
+    type BrandBrickExcludedPaymentMethods =
         | "master"
         | "visa"
         | "amex"
@@ -499,10 +499,9 @@ declare namespace bricks {
         | "tarshop"
         | "cmr"
         | "rapipago"
-        | "pagofacil"
-        | "mercadopago";
+        | "pagofacil";
 
-    type BrandBrickPaymentTypes = "credit_card" | "debit_card" | "ticket" | "account_money" | "mercado_credito";
+    type BrandBrickExcludedPaymentTypes = "credit_card" | "debit_card" | "ticket";
 
     interface CardPaymentController {
         unmount: () => void;


### PR DESCRIPTION
## Description
- Remove `mercadopago` from `excludedPaymentMethods`
- Remove `account_money` and `mercado_credito` from `excludedPaymentTypes`
- Rename `BrandBrickPaymentMethods` to `BrandBrickExcludedPaymentMethods`
- Rename `BrandBrickPaymentTypes` to `BrandBrickExcludedPaymentTypes`
- Add `resolve()` to `onSubmit` callback to ensure the Promise is returning `void`

## Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).